### PR TITLE
Adding in html files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# HTMLs
+*.html


### PR DESCRIPTION
Added html files to .gitignore  so that after running examples will not effect the repo if someone accidentally adds all the html to the commit.