### PR TITLE
Add instructions on extras to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ conda create -n yamm python=3.8
 Finally, use pip to install the package:
 ```
 conda activate yamm
-pip install -e <path/to/yamm> 
+pip install -e <path/to/yamm>[plot]
 ```
+
+There are a couple of extras available:
+
+* `osrm`: Needed by the `OsrmMatcher` to connect to the OSRM API.
+* `plot`: Needed to plot the result.
+
+At least `plot` is needed to run the examples.
 
 ### Alternate Methods
 
@@ -39,7 +46,7 @@ conda env create -f environment.yml
 Finally, use pip to install the package:
 ```
 conda activate yamm
-pip install -e <path/to/yamm> 
+pip install -e <path/to/yamm>[plot]
 ```
 
 
@@ -74,7 +81,3 @@ matcher = LCSSMatcher(road_map)
 
 matches = matcher.match_trace(trace)
 ```
-
-
-
-


### PR DESCRIPTION
So both `requests` and `folium` are already in `setup.py`, they are simply not included by default and you need to explicitly request for them. So let’s do that in README.

Close #26, towards #12 (not sure if it’s sufficient as a fix).