### PR TITLE
Fix a couple of easy mypy errors

### DIFF
--- a/yamm/constructs/trace.py
+++ b/yamm/constructs/trace.py
@@ -17,9 +17,6 @@ from yamm.utils.geohash import encode
 class Trace:
     _frame: GeoDataFrame
 
-    coords: List[Coordinate]
-    crs: CRS
-
     def __init__(self, frame: GeoDataFrame):
         self._frame = frame
 

--- a/yamm/utils/plot.py
+++ b/yamm/utils/plot.py
@@ -8,7 +8,7 @@ from shapely.geometry import Point
 
 from yamm.constructs.match import Match
 from yamm.constructs.trace import Trace
-from yamm.maps.map_interface import MapInterface
+from yamm.maps.nx.nx_map import NxMap
 from yamm.utils.crs import XY_CRS, LATLON_CRS
 
 
@@ -43,7 +43,7 @@ def plot_trace(trace, m=None, point_color="yellow", line_color="green"):
     return m
 
 
-def plot_matches(matches: List[Match], road_map: MapInterface):
+def plot_matches(matches: List[Match], road_map: NxMap):
     """
     plots a trace and the relevant matches on a folium map
 
@@ -81,7 +81,7 @@ def plot_matches(matches: List[Match], road_map: MapInterface):
         }
 
         return d
-    
+
 
     road_df = pd.DataFrame([match_to_road(m) for m in matches if m.road])
     road_df = road_df.loc[road_df.road_id.shift() != road_df.road_id]
@@ -119,7 +119,7 @@ def plot_matches(matches: List[Match], road_map: MapInterface):
     return fmap
 
 
-def plot_map(tmap: MapInterface, m=None):
+def plot_map(tmap: NxMap, m=None):
     # TODO make this generic to all map types, not just NxMap
     roads = list(tmap.g.edges(data=True))
     road_df = pd.DataFrame([r[2] for r in roads])

--- a/yamm/utils/plot.py
+++ b/yamm/utils/plot.py
@@ -2,12 +2,10 @@ from typing import List, Optional
 
 import folium
 import geopandas as gpd
-import numpy as np
 import pandas as pd
 from shapely.geometry import Point
 
 from yamm.constructs.match import Match
-from yamm.constructs.trace import Trace
 from yamm.maps.nx.nx_map import NxMap
 from yamm.utils.crs import XY_CRS, LATLON_CRS
 


### PR DESCRIPTION
closes #37 

- remove duplicate attribute declarations from `Trace` class
- type hint for both the utility function `plot_map()` and `plot_matches()` is `MapInterface`, but really expect a `NxMap`. switch type hint to the concrete class

also removed unused imports from `yamm/utils/plot.py`